### PR TITLE
Update katana wstETH vault

### DIFF
--- a/packages/cdn/vaults/747474.json
+++ b/packages/cdn/vaults/747474.json
@@ -767,7 +767,7 @@
     "isAggregator": false,
     "isBoosted": false,
     "isAutomated": false,
-    "isHighlighted": false,
+    "isHighlighted": true,
     "isPool": false,
     "shouldUseV2APR": false,
     "migration": {
@@ -794,7 +794,7 @@
       "isPoolTogether": false,
       "isCove": false,
       "isMorpho": false,
-      "isKatana": false,
+      "isKatana": true,
       "isPublicERC4626": false
     }
   }


### PR DESCRIPTION
This PR updates data in packages/cdn/vaults/747474.json.

Updates the katana wstETH vault to be highlighted and have isKatana flag set to true
0x1769111aa8ea46fee3ba23ef9b57f3cbe1873408