### PR TITLE
Tag Yearn Morpho USDT vault on Katana as Morpho

### DIFF
--- a/packages/cdn/vaults/747474.json
+++ b/packages/cdn/vaults/747474.json
@@ -46,6 +46,8 @@
     "address": "0x156c729c78076b7cd815d01ca6967c00c5ac8d9c",
     "name": "Morpho Yearn OG USDT Compounder",
     "registry": "0xd40ecf29e001c76dcc4cc0d9cd50520ce845b038",
+    "type": "Yearn Vault",
+    "kind": "Single Strategy",
     "isRetired": false,
     "isHidden": false,
     "isAggregator": false,
@@ -65,7 +67,7 @@
     "category": "Stablecoin",
     "displayName": "",
     "displaySymbol": "",
-    "description": "",
+    "description": "Supplies USDT to the Yearn-managed Meta Morpho vault on Katana, earning the underlying yield and auto-compounding all reward tokens except KAT, which can be claimed at https://app.merkl.xyz/users/.",
     "sourceURI": "",
     "uiNotice": "",
     "protocols": [],
@@ -76,12 +78,10 @@
       "isGimme": false,
       "isPoolTogether": false,
       "isCove": false,
-      "isMorpho": false,
+      "isMorpho": true,
       "isKatana": false,
       "isPublicERC4626": false
-    },
-    "type": "Yearn Vault",
-    "kind": "Single Strategy"
+    }
   },
   {
     "chainId": 747474,


### PR DESCRIPTION
This PR updates data in packages/cdn/vaults/747474.json.
Tag Yearn Morpho USDT vault on Katana as Morpho. `isMorpho=true`
Also adds description

Updated by: rossgalloway