### PR TITLE
Hide and remove `DAI-1 yVault Liquid Locker Compounder` from fancy

### DIFF
--- a/packages/cdn/vaults/1.json
+++ b/packages/cdn/vaults/1.json
@@ -23456,12 +23456,14 @@
     "address": "0xc5ab829b2f7cb3e869949747bc8c6f66ef2250cc",
     "name": "DAI-1 yVault Liquid Locker Compounder",
     "registry": "0xd40ecf29e001c76dcc4cc0d9cd50520ce845b038",
+    "type": "Yearn Vault",
+    "kind": "Multi Strategy",
     "isRetired": false,
-    "isHidden": false,
+    "isHidden": true,
     "isAggregator": false,
     "isBoosted": false,
     "isAutomated": false,
-    "isHighlighted": true,
+    "isHighlighted": false,
     "isPool": false,
     "shouldUseV2APR": false,
     "migration": {
@@ -23489,9 +23491,7 @@
       "isMorpho": false,
       "isKatana": false,
       "isPublicERC4626": false
-    },
-    "type": "Yearn Vault",
-    "kind": "Multi Strategy"
+    }
   },
   {
     "chainId": 1,


### PR DESCRIPTION
This PR updates data in packages/cdn/vaults/1.json.

Hide and remove `DAI-1 yVault Liquid Locker Compounder` from fancy

Updated by: rossgalloway