### PR TITLE
hide and remove `WETH-2 yVault Liquid Locker Compounder` from fancy

### DIFF
--- a/packages/cdn/vaults/1.json
+++ b/packages/cdn/vaults/1.json
@@ -19388,12 +19388,14 @@
     "address": "0xa89e83e39c8a1cb173d7a0c0201cd3956b57db6d",
     "name": "WETH-2 yVault Liquid Locker Compounder",
     "registry": "0xd40ecf29e001c76dcc4cc0d9cd50520ce845b038",
+    "type": "Yearn Vault",
+    "kind": "Multi Strategy",
     "isRetired": false,
-    "isHidden": false,
+    "isHidden": true,
     "isAggregator": false,
     "isBoosted": false,
     "isAutomated": false,
-    "isHighlighted": true,
+    "isHighlighted": false,
     "isPool": false,
     "shouldUseV2APR": false,
     "migration": {
@@ -19421,9 +19423,7 @@
       "isMorpho": false,
       "isKatana": false,
       "isPublicERC4626": false
-    },
-    "type": "Yearn Vault",
-    "kind": "Multi Strategy"
+    }
   },
   {
     "chainId": 1,


### PR DESCRIPTION
This PR updates data in packages/cdn/vaults/1.json.

hide and remove `WETH-2 yVault Liquid Locker Compounder` from fancy

Updated by: rossgalloway