### PR TITLE
hide and remove `crvUSD-2 yVault Liquid Locker Compounder` from fancy

### DIFF
--- a/packages/cdn/vaults/1.json
+++ b/packages/cdn/vaults/1.json
@@ -29763,12 +29763,14 @@
     "address": "0xf9a7084ec30238495b3f5c51f05ba7cd1c358dcf",
     "name": "crvUSD-2 yVault Liquid Locker Compounder",
     "registry": "0xd40ecf29e001c76dcc4cc0d9cd50520ce845b038",
+    "type": "Yearn Vault",
+    "kind": "Multi Strategy",
     "isRetired": false,
-    "isHidden": false,
+    "isHidden": true,
     "isAggregator": false,
     "isBoosted": false,
     "isAutomated": false,
-    "isHighlighted": true,
+    "isHighlighted": false,
     "isPool": false,
     "shouldUseV2APR": false,
     "migration": {
@@ -29796,9 +29798,7 @@
       "isMorpho": false,
       "isKatana": false,
       "isPublicERC4626": false
-    },
-    "type": "Yearn Vault",
-    "kind": "Multi Strategy"
+    }
   },
   {
     "chainId": 1,


### PR DESCRIPTION
This PR updates data in packages/cdn/vaults/1.json.

hide and remove `crvUSD-2 yVault Liquid Locker Compounder` from fancy

Updated by: rossgalloway