### PR TITLE
fix: sync job failing

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -33,7 +33,7 @@ jobs:
           bun-version: latest
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Run sync-vaults.ts
         run: bun run scripts/sync-vaults.ts
@@ -50,7 +50,7 @@ jobs:
       - name: Check for changes
         id: verify-changed-files
         run: |
-          if [ -n "$(git status --porcelain)" ]; then
+          if [ -n "$(git status --porcelain packages/cdn/)" ]; then
             echo "changed=true" >> $GITHUB_OUTPUT
           else
             echo "changed=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## What was happening

Job for syncing data was failing without any reasonable sign of error in the logic itself

## What was changed
One thing i noticed is that the bun lock file was being shown as modified, which was breaking the other checks done for it to trigger the syncs properly. By adding frozen lock, that solves it and allows for check to happen down the road 


https://github.com/yearn/cms/actions/runs/20241809538

is a successful job