### PR TITLE
Supply-chain hardening sweep

### DIFF
--- a/.bunfig.toml
+++ b/.bunfig.toml
@@ -1,4 +1,0 @@
-
-[install]
-minimumReleaseAge = 604800
-ignoreScripts = true

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,7 +1,4 @@
 [install]
-workspace = [
-  "packages/**"
-]
 minimumReleaseAge = 604800
 ignoreScripts = true
 exact = true

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -2,3 +2,6 @@
 workspace = [
   "packages/**"
 ]
+minimumReleaseAge = 604800
+ignoreScripts = true
+exact = true


### PR DESCRIPTION
Automated hardening pass:

- PM configs touched: bunfig.toml
- deps pinned from lockfile: 0
- deps range-stripped (fallback): 0
- workflow install lines frozen: 0
- workflow actions pinned to SHA: 0
