### PR TITLE
Pin Motion DOM for Vercel builds

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,6 +14,7 @@
         "@radix-ui/react-switch": "1.2.6",
         "@tanstack/react-query": "5.85.5",
         "framer-motion": "12.23.12",
+        "motion-dom": "12.23.12",
         "react": "19.1.1",
         "react-dom": "19.1.1",
         "react-icons": "5.5.0",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -17,6 +17,7 @@
 		"@radix-ui/react-switch": "1.2.6",
 		"@tanstack/react-query": "5.85.5",
 		"framer-motion": "12.23.12",
+		"motion-dom": "12.23.12",
 		"react": "19.1.1",
 		"react-dom": "19.1.1",
 		"react-icons": "5.5.0",


### PR DESCRIPTION
## Summary

- Pin `motion-dom` to `12.23.12` alongside `framer-motion@12.23.12`
- Record the direct dependency in the Bun lockfile

## Root cause

Vercel installs `packages/app` without the repository-level lockfile. A
cacheless install therefore resolved Framer Motion's permissive transitive
range to `motion-dom@12.42.2`, which no longer exports `activeAnimations`
expected by `framer-motion@12.23.12`. Rollup then failed during the production
build.

Pinning the compatible Motion DOM version makes cacheless deployments
deterministic without changing application behavior.

## Validation

- `bun install --frozen-lockfile` with Bun 1.3.12 at the repository root
- Cacheless standalone `packages/app` install with Bun 1.3.12
- `npm run build` production build
