### PR TITLE
Add isNeverShown and obsolete isHidden

### DIFF
--- a/docs/how-to-manage-cms-metadata-schemas.md
+++ b/docs/how-to-manage-cms-metadata-schemas.md
@@ -45,7 +45,22 @@ For fields like `protocols`, `type`, or `stability`, add new values to the enum:
 protocols: z.array(z.enum(['Curve', 'Balancer', 'NewProtocol'])),
 ```
 
-### 4. Test your changes
+### 4. Marking fields as obsolete
+
+To keep a field visible in the CMS while preventing further edits, mark it as obsolete in its Zod metadata:
+
+```ts
+legacyField: z.string().optional().meta({ obsolete: true }),
+```
+
+The `obsolete` flag is schema metadata only. It is not included in CDN metadata and cannot be changed from the CMS.
+Obsolete fields remain visible, validated, and present in saved metadata, but their form controls are disabled. Marking
+an object as obsolete also disables all fields nested inside it.
+
+Do not remove the field from the schema or make unrelated changes to its validation when marking it obsolete. This
+preserves compatibility with existing metadata.
+
+### 5. Test your changes
 
 ```bash
 bun dev

--- a/packages/app/next-env.d.ts
+++ b/packages/app/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/app/schemas/VaultMetadata.test.ts
+++ b/packages/app/schemas/VaultMetadata.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, test } from 'bun:test'
+import { VaultMetadataSchema } from './VaultMetadata'
+
+describe('VaultMetadataSchema', () => {
+  test('defaults isNeverShown to false', () => {
+    expect(VaultMetadataSchema.shape.isNeverShown.parse(undefined)).toBe(false)
+  })
+})

--- a/packages/app/schemas/VaultMetadata.ts
+++ b/packages/app/schemas/VaultMetadata.ts
@@ -9,7 +9,7 @@ export const VaultMetadataSchema = z.object({
   type: z.enum(['Yearn Vault', 'Experimental Yearn Vault', 'Automated Yearn Vault', 'Single Strategy', 'None']),
   kind: z.enum(['Multi Strategy', 'Legacy', 'Single Strategy', 'None']),
   isRetired: z.boolean(),
-  isHidden: z.boolean(),
+  isHidden: z.boolean().meta({ obsolete: true }),
   isAggregator: z.boolean(),
   isBoosted: z.boolean(),
   isAutomated: z.boolean(),

--- a/packages/app/schemas/VaultMetadata.ts
+++ b/packages/app/schemas/VaultMetadata.ts
@@ -10,6 +10,7 @@ export const VaultMetadataSchema = z.object({
   kind: z.enum(['Multi Strategy', 'Legacy', 'Single Strategy', 'None']),
   isRetired: z.boolean(),
   isHidden: z.boolean().meta({ obsolete: true }),
+  isNeverShown: z.boolean().default(false),
   isAggregator: z.boolean(),
   isBoosted: z.boolean(),
   isAutomated: z.boolean(),

--- a/packages/app/schemas/cms.ts
+++ b/packages/app/schemas/cms.ts
@@ -12,6 +12,7 @@ export const collections = {
     filterableBooleanFields: [
       'isRetired',
       'isHidden',
+      'isNeverShown',
       'isAggregator',
       'isBoosted',
       'isAutomated',

--- a/packages/app/src/components/SchemaForm.tsx
+++ b/packages/app/src/components/SchemaForm.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react'
 import { createContext, useContext, useEffect, useState } from 'react'
 import z from 'zod'
 import { cn } from '../../lib/cn'
+import { isSchemaFieldReadOnly } from '../lib/schemaField'
 import Input from './eg/elements/Input'
 import Switch from './eg/elements/Switch'
 import Textarea from './eg/elements/Textarea'
@@ -210,10 +211,11 @@ function renderField(
   readOnly = false,
 ) {
   const fieldPath = [...path, key]
+  const fieldReadOnly = isSchemaFieldReadOnly(schema, readOnly)
   const commonProps = {
     name: key,
     value: value ?? '',
-    disabled: readOnly,
+    disabled: fieldReadOnly,
     onChange: (e: React.ChangeEvent<any>) => {
       const val = schema.type === 'boolean' ? e.target.checked : e.target.value
       update(fieldPath, schema.type === 'number' ? parseFloat(val) : val)
@@ -222,15 +224,17 @@ function renderField(
 
   switch (schema.type) {
     case 'number':
-      return <Input type="number" {...commonProps} readOnly={readOnly} />
+      return <Input type="number" {...commonProps} readOnly={fieldReadOnly} />
     case 'string':
-      return renderStringField(key, schema, value, commonProps, update, fieldPath, readOnly)
+      return renderStringField(key, schema, value, commonProps, update, fieldPath, fieldReadOnly)
     case 'boolean':
-      return <Switch checked={value || false} onChange={(checked) => update(fieldPath, checked)} disabled={readOnly} />
+      return (
+        <Switch checked={value || false} onChange={(checked) => update(fieldPath, checked)} disabled={fieldReadOnly} />
+      )
     case 'object':
-      return renderObjectField(schema, value, update, fieldPath, readOnly)
+      return renderObjectField(schema, value, update, fieldPath, fieldReadOnly)
     case 'array':
-      return renderArrayField(key, schema, value, update, fieldPath, readOnly)
+      return renderArrayField(key, schema, value, update, fieldPath, fieldReadOnly)
     default:
       return null
   }

--- a/packages/app/src/components/SchemaForm.tsx
+++ b/packages/app/src/components/SchemaForm.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from 'react'
 import { createContext, useContext, useEffect, useState } from 'react'
 import z from 'zod'
 import { cn } from '../../lib/cn'
-import { isSchemaFieldReadOnly } from '../lib/schemaField'
+import { isSchemaFieldObsolete, isSchemaFieldReadOnly } from '../lib/schemaField'
 import Input from './eg/elements/Input'
 import Switch from './eg/elements/Switch'
 import Textarea from './eg/elements/Textarea'
@@ -92,6 +92,15 @@ function getEnumOptions(values: string[]) {
     value,
     label: value,
   }))
+}
+
+function FieldLabel({ name, schema, className }: { name: string; schema: JSONSchema; className?: string }) {
+  return (
+    <label htmlFor={name} className={className}>
+      {name}
+      {isSchemaFieldObsolete(schema) && <span className="ml-2 text-xs opacity-60">[obsolete]</span>}
+    </label>
+  )
 }
 
 function renderReadOnlyArray(value: string[]) {
@@ -192,9 +201,7 @@ function renderObjectField(
     <fieldset className="flex flex-col gap-8">
       {Object.entries(schema.properties || {}).map(([key, childSchema]) => (
         <div key={key} className="flex items-center justify-between gap-6">
-          <label htmlFor={key} className="w-42 text-right text-sm">
-            {key}
-          </label>
+          <FieldLabel name={key} schema={childSchema} className="w-42 text-right text-sm" />
           {renderField(key, childSchema, value?.[key], update, fieldPath, readOnly)}
         </div>
       ))}
@@ -255,7 +262,7 @@ export default function MetaData({ className, readOnly = false }: MetaDataProps)
         .filter(([key]) => !READ_ONLY_FIELDS.includes(key))
         .map(([key, schema]) => (
           <div key={key} className="py-3 flex items-center justify-between">
-            <label htmlFor={key}>{key}</label>
+            <FieldLabel name={key} schema={schema} />
             {renderField(key, schema, formState[key], updateField, [], readOnly)}
           </div>
         ))}

--- a/packages/app/src/lib/schemaField.test.ts
+++ b/packages/app/src/lib/schemaField.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'bun:test'
+import { z } from 'zod'
+import { isSchemaFieldReadOnly } from './schemaField'
+
+describe('isSchemaFieldReadOnly', () => {
+  test('keeps an ordinary field editable', () => {
+    expect(isSchemaFieldReadOnly({}, false)).toBe(false)
+  })
+
+  test('disables a field marked obsolete in its Zod metadata', () => {
+    const schema = z.object({
+      legacyField: z.string().meta({ obsolete: true }),
+    })
+    const jsonSchema = z.toJSONSchema(schema)
+
+    expect(isSchemaFieldReadOnly(jsonSchema.properties?.legacyField ?? {}, false)).toBe(true)
+  })
+
+  test('honors form-wide read-only mode', () => {
+    expect(isSchemaFieldReadOnly({}, true)).toBe(true)
+  })
+
+  test('does not disable fields when obsolete is false', () => {
+    expect(isSchemaFieldReadOnly({ obsolete: false }, false)).toBe(false)
+  })
+})

--- a/packages/app/src/lib/schemaField.test.ts
+++ b/packages/app/src/lib/schemaField.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import { z } from 'zod'
-import { isSchemaFieldReadOnly } from './schemaField'
+import { isSchemaFieldObsolete, isSchemaFieldReadOnly } from './schemaField'
 
 describe('isSchemaFieldReadOnly', () => {
   test('keeps an ordinary field editable', () => {
@@ -12,8 +12,10 @@ describe('isSchemaFieldReadOnly', () => {
       legacyField: z.string().meta({ obsolete: true }),
     })
     const jsonSchema = z.toJSONSchema(schema)
+    const legacyField = jsonSchema.properties?.legacyField ?? {}
 
-    expect(isSchemaFieldReadOnly(jsonSchema.properties?.legacyField ?? {}, false)).toBe(true)
+    expect(isSchemaFieldObsolete(legacyField)).toBe(true)
+    expect(isSchemaFieldReadOnly(legacyField, false)).toBe(true)
   })
 
   test('honors form-wide read-only mode', () => {

--- a/packages/app/src/lib/schemaField.ts
+++ b/packages/app/src/lib/schemaField.ts
@@ -1,0 +1,9 @@
+export type SchemaFieldMetadata = {
+  obsolete?: boolean
+}
+
+export function isSchemaFieldReadOnly(schema: unknown, readOnly: boolean) {
+  return (
+    readOnly || (typeof schema === 'object' && schema !== null && (schema as SchemaFieldMetadata).obsolete === true)
+  )
+}

--- a/packages/app/src/lib/schemaField.ts
+++ b/packages/app/src/lib/schemaField.ts
@@ -2,8 +2,10 @@ export type SchemaFieldMetadata = {
   obsolete?: boolean
 }
 
+export function isSchemaFieldObsolete(schema: unknown) {
+  return typeof schema === 'object' && schema !== null && (schema as SchemaFieldMetadata).obsolete === true
+}
+
 export function isSchemaFieldReadOnly(schema: unknown, readOnly: boolean) {
-  return (
-    readOnly || (typeof schema === 'object' && schema !== null && (schema as SchemaFieldMetadata).obsolete === true)
-  )
+  return readOnly || isSchemaFieldObsolete(schema)
 }


### PR DESCRIPTION
### Summary

Add code-only schema metadata for marking CMS fields obsolete. Obsolete fields remain visible and validated but cannot be edited through the UI.

Mark the existing vault `isHidden` field obsolete and add its replacement, `isNeverShown`, with a default value of `false`. Existing CDN metadata remains compatible without an immediate backfill.

### How to review

1. Review `schemaField.ts` and `SchemaForm.tsx` for obsolete-field detection and inherited read-only behavior.
2. Review `VaultMetadata.ts` for the obsolete `isHidden` flag and new `isNeverShown` field.
3. Confirm `isNeverShown` appears in the vault boolean filters.
4. Open a vault in the CMS and verify:
   - `isHidden` remains visible but disabled.
   - `isNeverShown` is editable and defaults to `false`.
   - Other vault fields remain editable.

The generated `next-env.d.ts` route-type path update is unrelated to the metadata behavior.

### Test plan

- [x] Automated: `bun test packages/app` — 18 tests pass
- [x] Automated: `bun run lint`
- [x] Automated: `bun run --cwd packages/app tslint`
- [x] Validate all 1,215 existing vault records against the updated schema
- [ ] Manual: verify `isHidden` is disabled in the vault editor
- [ ] Manual: verify `isNeverShown` defaults to false and remains editable

### Risk / impact

Low risk. No existing CDN records are changed in this PR. Zod supplies `false` when `isNeverShown` is absent, while existing `isHidden` values remain stored and validated.

The follow-up stacked PR will copy every existing `isHidden` value into `isNeverShown`. It should use this branch as its base so the data migration can be reviewed separately.
